### PR TITLE
Set -source and -target to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,11 @@
      
       <properties>
           <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
       </properties>
      
-	  <build>
+      <build>
           <plugins>
               <plugin>
                   <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
From minecraft 1.12 and on the server code is now compiled for java 8, so this plugin should also use Java 8